### PR TITLE
Refactor CloseTransitionNode.

### DIFF
--- a/LightRoute/LightRoute.swift
+++ b/LightRoute/LightRoute.swift
@@ -124,20 +124,19 @@ public extension TransitionHandler where Self: UIViewController {
 	}
 	
     /// Close current module.
-	func closeCurrentModule(animated: Bool) -> CloseTransitionNode {
+	func closeCurrentModule() -> CloseTransitionNode {
         let node = CloseTransitionNode(root: self)
-        node.animated = animated
-        
+
         node.postLinkAction { [unowned self] in
             if let parent = self.parent, parent is UINavigationController {
                 let navigationController = parent as! UINavigationController
                 
                 if navigationController.childViewControllers.count > 1 {
                     guard let controller = navigationController.childViewControllers.dropLast().last else { return }
-                    navigationController.popToViewController(controller, animated: animated)
+                    navigationController.popToViewController(controller, animated: node.isAnimated)
                 }
             } else if self.presentingViewController != nil {
-                self.dismiss(animated: animated, completion: nil)
+                self.dismiss(animated: node.isAnimated, completion: nil)
             }
 
         }

--- a/LightRoute/Protocols/TransitionHandler.swift
+++ b/LightRoute/Protocols/TransitionHandler.swift
@@ -58,9 +58,8 @@ public protocol TransitionHandler: class {
     ///
     /// Methods close current module.
     ///
-    /// - Parameter animated: Transition animate state.
     /// - Returns: Transition node instance with setups.
     ///
-    func closeCurrentModule(animated: Bool) -> CloseTransitionNode
+    func closeCurrentModule() -> CloseTransitionNode
 }
 

--- a/LightRoute/TransitionNodes/CloseTransitionNode.swift
+++ b/LightRoute/TransitionNodes/CloseTransitionNode.swift
@@ -29,24 +29,24 @@ public enum CloseTransitionStyle {
     case `default`
     
     /// Make custom navigation controller close action.
-    case navigationController(style: CloseTransitionNavigationStyle)
-}
+    case navigation(style: NavigationStyle)
 
-/// Responds transition case how navigation controller will be close.
-public enum CloseTransitionNavigationStyle {
-    
-    /// Make pop to view controller for you controller.
-    case pop(to: UIViewController)
-    
-    /// Make default pop on one controller back.
-    case simplePop
-    
-    /// Make pop to root action.
-    case toRoot
-    
-    /// Return you to finded controller in navigation stack.
-    /// - Note: Fot this style, you should be complete method `find(pop:)`
-    case findedPop
+    /// Responds transition case how navigation controller will be close.
+    public enum NavigationStyle {
+
+        /// Make pop to view controller for you controller.
+        case pop(to: UIViewController)
+
+        /// Make default pop on one controller back.
+        case simplePop
+
+        /// Make pop to root action.
+        case toRoot
+
+        /// Return you to finded controller in navigation stack.
+        /// - Note: Fot this style, you should be complete method `find(pop:)`
+        case findedPop
+    }
 }
 
 public final class CloseTransitionNode {
@@ -117,7 +117,7 @@ public final class CloseTransitionNode {
             }
             
             switch style {
-            case .navigationController(style: let navStyle):
+            case .navigation(style: let navStyle):
                 
                 guard let parent = root.parent, let navigationController = parent as? UINavigationController
                     else { throw LightRouteError.viewControllerWasNil("Navigation") }
@@ -154,6 +154,17 @@ public final class CloseTransitionNode {
     ///
     public func perform() throws {
         try self.postLinkAction?()
+    }
+
+    ///
+    /// Turn on or off animate for current transition.
+    /// - Note: By default this transition is animated.
+    ///
+    /// - Parameter animate: Animate or not current transition ifneeded.
+    ///
+    public func transition(animate: Bool) -> CloseTransitionNode {
+        self.animated = animate
+        return self
     }
     
     // MARK: -

--- a/README.md
+++ b/README.md
@@ -253,10 +253,20 @@ func openModule(userIdentifier: String) {
 If you want initiate close current module, you should be use:
 
 ```swift
-.closeCurrentModule(animated: Bool)
+.closeCurrentModule()
 ```
 
 And after this you can use `perform()` method for initiate close method.
+
+**Animate close transition**
+
+This methods can animate your current transition.
+
+```swift
+.transition(animate: false)
+```
+
+Note: Default `true`
 
 **Custom close style**
 
@@ -267,11 +277,11 @@ If you need call `popToViewController(:animated)` for your custom controller, yo
 
 ````swift
 try? transitionHandler
-  .closeCurrentModule(animated: true)
+  .closeCurrentModule()
   .find(pop: { controller -> Bool
     return controller is MyCustomController
   })
-  .preferred(style: .navigationController(style: .findedPop))
+  .preferred(style: .navigation(style: .findedPop))
   .perform()
 ````
 


### PR DESCRIPTION
Delete `animated` param from func signature -> use variable.
Update Readme for refactored CloseTransitionNode